### PR TITLE
Update Timeout in Incident_function

### DIFF
--- a/src/Fonctions/Incident_fonction.js
+++ b/src/Fonctions/Incident_fonction.js
@@ -484,7 +484,7 @@ export const IncidentData = () => {
             console.log("Payload being sent:", payload);
 
             // Envoi vers FastAPI
-            await axios.post(fastapiUrl, payload);
+            await axios.post(fastapiUrl, payload, { timeout: 120000 });
         } catch (error) {
             console.error(
                 "Error sending prediction (Axios error):",


### PR DESCRIPTION
Frontend was sending multiple prediction requests to the prediction endpoint due to the short timeout. I increased the length to fix this issue.